### PR TITLE
fix LD A, I instruction

### DIFF
--- a/Z80.js
+++ b/Z80.js
@@ -2329,7 +2329,11 @@ ed_instructions[0x56] = function()
 ed_instructions[0x57] = function()
 {
    a = i;
+   flags.S = i 
+   flags.Z = i ? 1 : 0;
+   flags.H = 0;
    flags.P = iff2;
+   flags.N = 0;
 };
 // 0x58 : IN E, (C)
 ed_instructions[0x58] = function()

--- a/Z80.js
+++ b/Z80.js
@@ -2329,8 +2329,8 @@ ed_instructions[0x56] = function()
 ed_instructions[0x57] = function()
 {
    a = i;
-   flags.S = i 
-   flags.Z = i ? 1 : 0;
+   flags.S = i & 0x80 ? 1 : 0;
+   flags.Z = i ? 0 : 1;
    flags.H = 0;
    flags.P = iff2;
    flags.N = 0;


### PR DESCRIPTION
I think the `LD A, I` is not properly implemented (it fails the [FUSE](https://github.com/mattgodbolt/Miracle/blob/master/test/test.html) emulator tests).
 
The [Z80 CPU User Manual](http://www.zilog.com/manage_directlink.php?filepath=docs/z80/um0080&extn=.pdf) says at page 94:

```
   The contents of the Interrupt Vector Register I are loaded to the Accumulator.
   S is set if the I Register is negative; otherwise, it is reset.
   Z is set if the I Register is 0; otherwise, it is reset.
   H is reset.
   P/V contains contents of IFF2.
   N is reset.
   C is not affected.
   If an interrupt occurs during execution of this instruction, the Parity flag contains a 0.   
```
I don't know how to implement the last one, but I fixed the condition bits.

With this fix applied, it is able to pass that particular test case in [FUSE](https://github.com/mattgodbolt/Miracle/blob/master/test/test.html).

